### PR TITLE
Send request body on command cancel

### DIFF
--- a/lib/qubole/command.rb
+++ b/lib/qubole/command.rb
@@ -85,7 +85,7 @@ module Qubole
     # Cancel command
     # 
     def cancel
-      Qubole.put("/commands/#{id}")
+      Qubole.put("/commands/#{id}", status: 'kill')
     end
   end
 end

--- a/lib/qubole/version.rb
+++ b/lib/qubole/version.rb
@@ -1,3 +1,3 @@
 module Qubole
-  VERSION = "0.0.3"
+  VERSION = "0.0.4"
 end

--- a/spec/qubole/command_spec.rb
+++ b/spec/qubole/command_spec.rb
@@ -69,7 +69,7 @@ module Qubole
 
     describe "#cancel" do
       it "cancels command execution" do
-        expect(Qubole).to receive(:put).with("/commands/1")
+        expect(Qubole).to receive(:put).with("/commands/1", status: 'kill')
         subject.cancel
       end
     end


### PR DESCRIPTION
This PR attempts to add a missing request body for `Command::cancel`. According to the [Qubole API documentation](https://docs.qubole.com/en/latest/rest-api/command_api/cancel-a-command.html), a status argument of `{status: 'kill'}` is required to cancel a command.